### PR TITLE
feat: deactivated platform

### DIFF
--- a/apps/ng-integration/src/app/app.component.html
+++ b/apps/ng-integration/src/app/app.component.html
@@ -2,37 +2,37 @@
     <div class="px-16 py-2 bg-black text-white">
         <div class="flex flex-row -mx-3">
             <div class="px-3">
-                <a routerLink="/">
+                <a routerLink="/" routerLinkActive="text-blue-300" [routerLinkActiveOptions]="{exact: true}">
                     Home
                 </a>
             </div>
             <div class="px-3">
-                <a routerLink="/posts">
+                <a routerLink="/posts/all" routerLinkActive="text-blue-300">
                     Posts
                 </a>
             </div>
             <div class="px-3">
-                <a routerLink="/posts/with-breadcrumbs">
+                <a routerLink="/posts/with-breadcrumbs" routerLinkActive="text-blue-300">
                     Breadcrumbs
                 </a>
             </div>
             <div class="px-3">
-                <a routerLink="/posts/await">
+                <a routerLink="/posts/await" routerLinkActive="text-blue-300">
                     Await
                 </a>
             </div>
             <div class="px-3">
-                <a routerLink="/posts/paginated">
+                <a routerLink="/posts/paginated" routerLinkActive="text-blue-300">
                     Paginated
                 </a>
             </div>
             <div class="px-3">
-                <a routerLink="/posts/with-comments">
+                <a routerLink="/posts/with-comments" routerLinkActive="text-blue-300">
                     With comments
                 </a>
             </div>
             <div class="px-3">
-                <a routerLink="/posts/with-user">
+                <a routerLink="/posts/with-user" routerLinkActive="text-blue-300">
                     With user &amp; comments
                 </a>
             </div>

--- a/apps/ng-integration/src/app/app.component.html
+++ b/apps/ng-integration/src/app/app.component.html
@@ -67,6 +67,6 @@
 </div>
 
 
-<div class="px-16 py-24">
+<div class="px-16">
     <router-outlet></router-outlet>
 </div>

--- a/apps/ng-integration/src/app/posts/posts-index/posts-index.component.html
+++ b/apps/ng-integration/src/app/posts/posts-index/posts-index.component.html
@@ -1,5 +1,5 @@
 <div class="flex flex-row -mx-6">
-    <div class="w-1/3 px-6 h-screen overflow-y-auto">
+    <div class="w-1/3 px-6 py-24 h-screen overflow-y-auto">
         <frrri-many path="entities.posts" #posts>
             <ng-container *ngIf="posts.loaded$ | async">
                 <div class="-my-2">
@@ -38,7 +38,7 @@
             </div>
         </frrri-many>
     </div>
-    <div class="w-2/3 px-6 h-screen overflow-y-auto">
+    <div class="w-2/3 px-6 py-24 h-screen overflow-y-auto">
         <router-outlet></router-outlet>
     </div>
 </div>

--- a/apps/ng-integration/src/app/posts/posts-routing.module.ts
+++ b/apps/ng-integration/src/app/posts/posts-routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { OperationContext } from '@ng-frrri/ngxs/internal';
 import { frrri, operate } from '@ng-frrri/router-middleware';
 import { activeBreadcrumb, activeMeta, getActive, getMany, populate, reset, staticBreadcrumb, staticMeta } from '@ng-frrri/router-middleware/operators';
 import { PostsIndexComponent } from './posts-index/posts-index.component';
@@ -123,6 +124,7 @@ const routes: Routes = [
                 to: users,
                 idPath: 'userId',
                 idSource: posts,
+                operations: [OperationContext.Many],
             }),
             getMany(posts, { params: { _page: '1', _limit: '5' } }),
             staticMeta({ title: 'Posts with user' }),
@@ -137,12 +139,14 @@ const routes: Routes = [
                     to: comments,
                     idPath: 'postId',
                     idSource: comments,
+                    operations: [OperationContext.One],
                 }),
                 populate({
                     from: posts,
                     to: users,
                     idPath: 'userId',
                     idSource: posts,
+                    operations: [OperationContext.One],
                 }),
                 getActive(posts),
                 activeMeta(posts, {

--- a/apps/ng-integration/src/app/posts/posts-routing.module.ts
+++ b/apps/ng-integration/src/app/posts/posts-routing.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { frrri, operate } from '@ng-frrri/router-middleware';
-import { activeBreadcrumb, activeMeta, deactivate, getActive, getMany, populate, reset, staticBreadcrumb, staticMeta } from '@ng-frrri/router-middleware/operators';
+import { activeBreadcrumb, activeMeta, getActive, getMany, populate, reset, staticBreadcrumb, staticMeta } from '@ng-frrri/router-middleware/operators';
 import { PostsIndexComponent } from './posts-index/posts-index.component';
 import { PostsShowComponent } from './posts-show/posts-show.component';
 
@@ -21,7 +21,6 @@ const routes: Routes = [
         component: PostsIndexComponent,
         data: operate(
             reset(all),
-            deactivate(posts),
             getMany(posts),
         ),
         children: [{
@@ -37,7 +36,6 @@ const routes: Routes = [
         component: PostsIndexComponent,
         data: operate(
             reset(all),
-            deactivate(posts),
             getMany(posts),
             staticBreadcrumb({ title: 'all posts' }),
             staticMeta({ title: 'All posts ' }),
@@ -61,7 +59,6 @@ const routes: Routes = [
         component: PostsIndexComponent,
         data: operate(
             reset(all),
-            deactivate(posts),
             getMany(posts, { await: true }),
         ),
         children: [{
@@ -84,7 +81,6 @@ const routes: Routes = [
         component: PostsIndexComponent,
         data: operate(
             reset(all),
-            deactivate(posts),
             getMany(posts, { params: { _page: '1', _limit: '5' } }),
         ),
         children: [{
@@ -100,7 +96,6 @@ const routes: Routes = [
         component: PostsIndexComponent,
         data: operate(
             reset(all),
-            deactivate(posts),
             getMany(posts, { params: { _page: '1', _limit: '5' } }),
         ),
         children: [{
@@ -123,7 +118,6 @@ const routes: Routes = [
         component: PostsIndexComponent,
         data: operate(
             reset(all),
-            deactivate(posts),
             populate({
                 from: posts,
                 to: users,

--- a/libs/ngxs/src/libs/collection-state/collection.state.ts
+++ b/libs/ngxs/src/libs/collection-state/collection.state.ts
@@ -501,7 +501,6 @@ export class CollectionState<Entity = {}, IdType extends EntityIdType = string, 
                 if (!hasPopulations) { return of(result); }
 
                 const operation = Array.isArray(result) ? OperationContext.Many : OperationContext.One;
-                console.log('--> Population', this.populations, operation);
                 const populations = this.populations.filter(p => !p.operations || p.operations.includes(operation));
                 if (!populations.length) { return of(result); }
 

--- a/libs/ngxs/src/libs/collection-state/collection.state.ts
+++ b/libs/ngxs/src/libs/collection-state/collection.state.ts
@@ -188,7 +188,11 @@ export class CollectionState<Entity = {}, IdType extends EntityIdType = string, 
     }
 
     @DataAction()
-    public deactivate(): void {
+    public deactivate(id?: EntityIdType): void {
+        if (typeof id !== 'undefined') {
+            const isIdActive = this.ctx.getState().active?.[this.primaryKey].toString() === id.toString();
+            if (!isIdActive) { return; }
+        }
         this.ctx.patchState({ active: undefined } as any);
     }
 

--- a/libs/ngxs/src/libs/collection-state/collection.state.ts
+++ b/libs/ngxs/src/libs/collection-state/collection.state.ts
@@ -65,7 +65,7 @@ export class CollectionState<Entity = {}, IdType extends EntityIdType = string, 
                 ...this.populations ?? [],
                 operation,
             ],
-            p => p.statePath + p.toStatePath + p.idPath + p.idSource,
+            p => p.statePath + p.toStatePath + p.idPath + p.idSource + p.operations?.join(),
         );
     }
 
@@ -501,6 +501,7 @@ export class CollectionState<Entity = {}, IdType extends EntityIdType = string, 
                 if (!hasPopulations) { return of(result); }
 
                 const operation = Array.isArray(result) ? OperationContext.Many : OperationContext.One;
+                console.log('--> Population', this.populations, operation);
                 const populations = this.populations.filter(p => !p.operations || p.operations.includes(operation));
                 if (!populations.length) { return of(result); }
 

--- a/libs/ngxs/src/libs/middlewares/ngxs.router-middleware.ts
+++ b/libs/ngxs/src/libs/middlewares/ngxs.router-middleware.ts
@@ -7,7 +7,7 @@ import { CollectionState } from '../collection-state/collection.state';
 
 type StateFacade = CollectionState | PaginatedCollectionState;
 
-export class NgxsRouterMiddleware extends MiddlewareFactory(Platform.Resolver, Platform.NavigationEnd) implements Middleware {
+export class NgxsRouterMiddleware extends MiddlewareFactory(Platform.Resolver, Platform.NavigationEnd, Platform.Deactivated) implements Middleware {
     operate(operation: Operation, platform: Platform, route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
         let facade: StateFacade;
         if ('statePath' in operation && operation.statePath) {
@@ -19,6 +19,15 @@ export class NgxsRouterMiddleware extends MiddlewareFactory(Platform.Resolver, P
                 return this.onResolve(operation, facade, route, state);
             case Platform.NavigationEnd:
                 return this.onNavigationEnd(operation, facade, route, state);
+            case Platform.Deactivated:
+                return this.onDeactivated(operation, facade, route, state);
+        }
+    }
+
+    onDeactivated(operation: Operation, facade: StateFacade, route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+        switch (operation.type) {
+            case OperatorType.GetActive:
+                return facade.deactivate(route.params[operation.param]);
         }
     }
 

--- a/libs/router-middleware/internal/src/enums/platform.enum.ts
+++ b/libs/router-middleware/internal/src/enums/platform.enum.ts
@@ -1,4 +1,5 @@
 export enum Platform {
     Resolver = 'Resolver',
     NavigationEnd = 'NavigationEnd',
+    Deactivated = 'Deactivated',
 }

--- a/libs/router-middleware/operators/src/libs/crud/operators/get-active.operator.ts
+++ b/libs/router-middleware/operators/src/libs/crud/operators/get-active.operator.ts
@@ -16,7 +16,7 @@ export function getActive(
     return {
         type: OperatorType.GetActive as OperatorType.GetActive,
         statePath,
-        platforms: [Platform.Resolver],
+        platforms: [Platform.Resolver, Platform.Deactivated],
         ...options,
     };
 }

--- a/libs/router-middleware/src/frrri.module.ts
+++ b/libs/router-middleware/src/frrri.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { ModuleWithProviders, NgModule } from '@angular/core';
+import { DeactivatedPlatform } from './platforms/deactivated.platform';
 import { NavigationEndPlatform } from './platforms/navigation-end.platform';
 import { ResolverPlatform } from './platforms/resolver.platform';
 import { BreadcrumbsService } from './services/breadcrumbs.service';
@@ -12,6 +13,7 @@ export class FrrriModule {
 
     constructor(
         protected navigationEndPlatform: NavigationEndPlatform,
+        protected deactivatedPlatform: DeactivatedPlatform,
         protected breadcrumbsService: BreadcrumbsService,
         protected metaService: MetaService,
     ) { }
@@ -24,6 +26,7 @@ export class FrrriModule {
                 ResolverPlatform,
                 BreadcrumbsService,
                 MetaService,
+                DeactivatedPlatform,
             ],
         };
     }

--- a/libs/router-middleware/src/frrri.ts
+++ b/libs/router-middleware/src/frrri.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { DeactivatedPlatform } from './platforms/deactivated.platform';
 import { ResolverPlatform } from './platforms/resolver.platform';
 
 export function frrri(
@@ -9,6 +10,11 @@ export function frrri(
             ['FRRRI']: ResolverPlatform,
             ...route.resolve,
         };
+
+        route.canDeactivate = [
+            DeactivatedPlatform,
+            ...(route.canDeactivate || []),
+        ];
 
         route.children = route.children
             ? frrri(route.children)

--- a/libs/router-middleware/src/platforms/deactivated.platform.ts
+++ b/libs/router-middleware/src/platforms/deactivated.platform.ts
@@ -17,7 +17,6 @@ export class DeactivatedPlatform extends PlatformFactory(Platform.Deactivated) i
     constructor(protected injector: Injector) {
         super(injector);
         const router = this.injector.get(Router);
-        console.log('Hello');
         router.events.pipe(
             filter(startEvent => startEvent instanceof NavigationStart),
             concatMapTo(

--- a/libs/router-middleware/src/platforms/deactivated.platform.ts
+++ b/libs/router-middleware/src/platforms/deactivated.platform.ts
@@ -1,0 +1,47 @@
+import { Injectable, Injector } from '@angular/core';
+import { ActivatedRouteSnapshot, ActivationEnd, CanDeactivate, NavigationStart, Router, RouterStateSnapshot } from '@angular/router';
+import { Platform } from '@ng-frrri/router-middleware/internal';
+import { concatMapTo, filter, map, mapTo, take } from 'rxjs/operators';
+import { PlatformFactory } from '../factories/platform.factory';
+import { toObservable } from '../helpers/is-observable';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class DeactivatedPlatform extends PlatformFactory(Platform.Deactivated) implements CanDeactivate<any> {
+    cache: {
+        route: ActivatedRouteSnapshot;
+        state: RouterStateSnapshot;
+    };
+
+    constructor(protected injector: Injector) {
+        super(injector);
+        const router = this.injector.get(Router);
+        console.log('Hello');
+        router.events.pipe(
+            filter(startEvent => startEvent instanceof NavigationStart),
+            concatMapTo(
+                router.events.pipe(
+                    filter(event => event instanceof ActivationEnd),
+                    take(1),
+                    map((event: ActivationEnd) => event.snapshot),
+                ),
+            ),
+        )
+            .subscribe(
+                () => this['onDeactivated']?.(),
+            );
+    }
+
+    canDeactivate(component: any, currentRoute: ActivatedRouteSnapshot, currentState: RouterStateSnapshot, nextState?: RouterStateSnapshot) {
+        this.cache = { route: currentRoute, state: currentState };
+        return true;
+    }
+
+    onDeactivated() {
+        if (!this.cache) { return true; }
+        const result = this.resolve(this.cache.route, this.cache.state);
+        this.cache = undefined;
+        return toObservable(result).pipe(mapTo(true));
+    }
+}


### PR DESCRIPTION
Automatically revert operations after a route has been deactivated.

See implementation of `onDeactivated()` in `ngxs.router-middleware.ts`. We revert `getActive()` when leaving the route.